### PR TITLE
feat: remove unused BackgammonMoveInProgress type and fix BackgammonMoveReady origin

### DIFF
--- a/src/move.ts
+++ b/src/move.ts
@@ -15,7 +15,6 @@ import {
 
 export type BackgammonMoveStateKind =
   | 'ready'
-  | 'in-progress'
   | 'completed'
   | 'confirmed'
 
@@ -54,13 +53,6 @@ export interface BackgammonMoveBase {
 
 export interface BackgammonMoveReady extends BackgammonMoveBase {
   stateKind: 'ready'
-  origin: BackgammonMoveOrigin
-}
-
-export interface BackgammonMoveInProgress extends BackgammonMoveBase {
-  stateKind: 'in-progress'
-  origin: BackgammonMoveOrigin
-  destination: BackgammonMoveDestination
 }
 
 export interface BackgammonMoveCompletedWithMove extends BackgammonMoveBase {
@@ -105,7 +97,6 @@ export type BackgammonMoveConfirmed =
 
 export type BackgammonMove =
   | BackgammonMoveReady
-  | BackgammonMoveInProgress
   | BackgammonMoveCompleted
   | BackgammonMoveConfirmed
 
@@ -157,5 +148,4 @@ export interface MoveClass {
     move: BackgammonMoveReady,
     isDryRun?: boolean
   ) => BackgammonMoveResult | BackgammonMoveDryRunResult
-  confirmMove: (move: BackgammonMoveInProgress) => BackgammonMoveConfirmed
 }


### PR DESCRIPTION
## Summary
Remove unused `BackgammonMoveInProgress` type and fix `BackgammonMoveReady` origin attribute per issue #157

## Changes

### Type System Cleanup
- ✅ Remove `BackgammonMoveInProgress` interface (lines 60-64)
- ✅ Remove `'in-progress'` from `BackgammonMoveStateKind` union (line 18)
- ✅ Remove `| BackgammonMoveInProgress` from `BackgammonMove` union (line 108)
- ✅ Remove `origin: BackgammonMoveOrigin` from `BackgammonMoveReady` (line 57)
- ✅ Remove `confirmMove` from `MoveClass` interface (line 160)

## Rationale
- `BackgammonMoveInProgress` was defined but never used in execution flow
- Move transitions go directly `ready` → `completed`
- `BackgammonMoveReady` incorrectly required origin - ready moves represent available die values, not fixed origins
- Origins are in `possibleMoves` array and selected when player clicks checker

## Benefits
- ✅ Cleaner type system with removed unused complexity
- ✅ Conceptual clarity - ready moves correctly represent available die values
- ✅ Reduced maintenance burden from dead code
- ✅ Better documentation accuracy

## Testing
- ✅ No tests in types package (types-only package)
- ✅ Core package tests pass (307/307)

## Related
- Closes #157
- Requires companion PR in nodots-backgammon-core

🤖 Generated with [Claude Code](https://claude.com/claude-code)