### PR TITLE
feat: migrate BackgammonMoves from Set to Array (issue #159)

### DIFF
--- a/src/move.ts
+++ b/src/move.ts
@@ -110,7 +110,7 @@ export interface BackgammonMoveDryRunResult {
   move: BackgammonMoveReady | BackgammonMoveCompleted
 }
 
-export type BackgammonMoves = Set<BackgammonMove>
+export type BackgammonMoves = BackgammonMove[]
 
 export interface MoveProps {
   move: BackgammonMove


### PR DESCRIPTION
Phase 1: TYPES package

Migrates root type definition from Set to Array.

Changes:
- Changed BackgammonMoves from Set<BackgammonMove> to BackgammonMove[]
- Updated test files to use array syntax
- Package builds successfully

This is the foundation change that enables simplification across CORE, API, and CLIENT.

Related: https://github.com/nodots/nodots-backgammon/issues/159