### PR TITLE
feat: doubling cube support

### DIFF
--- a/docs/doubling-cube-plan.md
+++ b/docs/doubling-cube-plan.md
@@ -1,0 +1,9 @@
+# Doubling Cube – Types Plan
+
+This file scaffolds the draft PR with no functional changes.
+
+- Add cube state types (value, owner, centered, available)
+- Add offer types: double, take, pass; pending offer structure
+- Extend game state with cube fields and match flags (Crawford optional)
+- Export request/response types for API/CLI/client integration
+- Changelog + version bump


### PR DESCRIPTION
# Doubling Cube – Types

Introduce type support for doubling cube across the platform.

- Add cube state and offer types
- Extend game and history types
- Export API contracts for double/take/pass