### PR TITLE
Phase 3.1: scope to @nodots, 1.0.0-rc.1, semver deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@nodots-llc/backgammon-types",
-  "version": "4.6.4-staging.15",
+  "name": "@nodots/backgammon-types",
+  "version": "1.0.0-rc.1",
   "description": "Type definitions for Nodots Backgammon",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -37,7 +37,7 @@
   "license": "GPL-3.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nodots/nodots-backgammon-types.git"
+    "url": "git+https://github.com/nodots/backgammon-types.git"
   },
   "keywords": [
     "backgammon",

--- a/src/play.ts
+++ b/src/play.ts
@@ -17,7 +17,7 @@
  * - **API Responses**: Always returns `moves` as an Array (JSON-serialized).
  *
  * - **Client Applications**: Should always expect `moves` to be an Array. Use the
- *   `transformGameData` utility or `ensureArray` from `@nodots-llc/backgammon-api-utils`
+ *   `transformGameData` utility or `ensureArray` from `@nodots/backgammon-api-utils`
  *   if there's any doubt about the incoming data format.
  *
  * When consuming game data from APIs or WebSocket messages:


### PR DESCRIPTION
Mechanical Phase 3.1 sweep: @nodots-llc/* → @nodots/*, bump to 1.0.0-rc.1, file: → semver for inter-package deps, tsconfig refs removed, source imports swapped. Builds verified locally.