### PR TITLE
types(play): type undo.frames as BackgammonGameMoving[] on BasePlay

### DIFF
--- a/src/play.ts
+++ b/src/play.ts
@@ -34,6 +34,9 @@ import { BackgammonBoard } from './board'
 import { BackgammonMoveOrigin } from './checkercontainer'
 import { BackgammonCube } from './cube'
 import { BackgammonDiceRolled, BackgammonDieValue } from './dice'
+// Type-only import: erased at compile time, so the play.ts <-> game.ts file
+// cycle it introduces has no runtime effect.
+import type { BackgammonGameMoving } from './game'
 import { BackgammonMoveCompleted, BackgammonMoves } from './move'
 import {
   BackgammonPlayer,
@@ -71,6 +74,13 @@ interface BasePlay {
    */
   moves?: BackgammonMoves
   /**
+   * Turn-local undo stack. Frames are complete pre-move snapshots of the
+   * moving game state, pushed before each move and popped on undo. Only a
+   * play in the 'moving' state accumulates frames, but the field lives on the
+   * base so callers can read it off any BackgammonPlay without narrowing.
+   */
+  undo?: { frames: BackgammonGameMoving[] }
+  /**
    * The maximum number of dice any legal ordering can consume from the
    * turn-start board (0-2 for a regular roll, 0-4 for doubles). Computed once
    * when the play is initialized and used to enforce the rule that a player
@@ -106,9 +116,6 @@ export type BackgammonPlayMoving = Play & {
   stateKind: 'moving'
   player: BackgammonPlayerMoving
   moves: BackgammonMoves
-  // Turn-local undo stack. Frames are complete pre-move snapshots of the moving game state.
-  // Typed as any[] here to avoid circular dependency on BackgammonGameMoving at the types level.
-  undo?: { frames: any[] }
 }
 
 export type BackgammonPlayMoved = Play & {


### PR DESCRIPTION
Supports the Game/index.ts decomposition epic (nodots/backgammon-core#132) and the `as any` removal (nodots/backgammon-core#96).

### What changed
- Promote the turn-local `undo` stack from `BackgammonPlayMoving` up to `BasePlay`.
- Type its frames as `BackgammonGameMoving[]` (was `any[]`) via a **type-only** `import type { BackgammonGameMoving } from './game'`.
- The type-only import is erased at compile time, so the `play.ts` ↔ `game.ts` file cycle it introduces has no runtime effect. Removes the old comment that claimed `any[]` was required to avoid a circular dependency.

### Why
Lets `backgammon-core` read `game.activePlay.undo.frames` without `as any` casts. The only workspace consumer of `.undo.frames` (`client` `UndoButton.tsx`) reads through a `game as any` cast, so it is unaffected by the tightening.

### Verification
- `npm run build` (tsc) clean.
- Pre-existing `__tests__/build.test.ts` failure in this package (missing node types in its test tsconfig) is unrelated to this change.

Refs nodots/backgammon-core#96, nodots/backgammon-core#132