### PR TITLE
Add resignationOffer to BackgammonGame (1.0.5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nodots/backgammon-types",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Type definitions for Nodots Backgammon",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/game.ts
+++ b/src/game.ts
@@ -104,6 +104,15 @@ export interface BackgammonGameStatistics {
   }>
 }
 
+// A pending resignation offer. The game's stateKind is unchanged while the
+// offer is open; accept completes the game at the offered points (times cube),
+// decline clears the offer and play resumes.
+export interface BackgammonResignationOffer {
+  offeredById: string // player.id of the player offering to resign
+  points: 1 | 2 | 3 // simple | gammon | backgammon stakes offered
+  offeredAt: Date
+}
+
 export interface BackgammonGameTiming {
   timeLimit?: number // in seconds, undefined = no limit
   timePerMove?: number // in seconds, undefined = no limit
@@ -151,6 +160,8 @@ interface BaseGame {
   }
   // Match context - present when game is part of a match
   matchInfo?: MatchInfo
+  // Present only while a resignation offer awaits the opponent's response
+  resignationOffer?: BackgammonResignationOffer
   settings: {
     allowUndo?: boolean
     allowResign?: boolean


### PR DESCRIPTION
A pending resignation is now representable: `BackgammonResignationOffer` (offeredById, points 1|2|3, offeredAt) as an optional field on the game. stateKind is unchanged while an offer is open; accept completes the game, decline clears the field.

Part of the resignation offer/decline flow (closes the unilateral-resign gap where a human facing a certain gammon could resign 1 point against a robot). Publish as 1.0.5 BEFORE merging the core/ai/api/client PRs — their CI builds resolve ^1.0.x from npm.